### PR TITLE
Added search endpoint for CTFs

### DIFF
--- a/backend/db/queries/ctf.sql
+++ b/backend/db/queries/ctf.sql
@@ -2,6 +2,18 @@
 SELECT * FROM ctfs
 ORDER BY start_date;
 
+-- name: SearchCTFs :many
+SELECT
+    *
+FROM
+    ctfs
+WHERE
+    (sqlc.arg(name) IS NULL OR ctfs.name LIKE CONCAT('%', sqlc.arg(name), '%')) 
+    and (sqlc.arg(description) IS NULL OR ctfs.description LIKE CONCAT('%', sqlc.arg(description), '%'))
+ORDER BY start_date;
+
+
+
 -- name: GetCTFByPhrase :one
 SELECT * FROM ctfs
 WHERE phrase = ? LIMIT 1;

--- a/backend/handler/ctfs.go
+++ b/backend/handler/ctfs.go
@@ -2,7 +2,9 @@ package handler
 
 import (
 	"context"
+	"fmt"
 	"net/http"
+	"time"
 
 	db "github.com/digitaldisarray/ctfcollab/db/sqlc"
 	"github.com/labstack/echo/v4"
@@ -123,4 +125,87 @@ func (h *Handler) CreateChallenge(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusOK, "Updated")
+}
+
+func (h *Handler) GetAllCTFs(c echo.Context) error {
+
+	ctx := context.Background()
+	ctfs, err := h.Queries.ListAllCTFs(ctx)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+
+	return c.JSON(http.StatusOK, ctfs)
+}
+
+// helper struct for SearchCTFs
+type OuterSearchParams struct {
+	Name        interface{} `json:"name"`
+	Description interface{} `json:"description"`
+	StartDate   string      `json:"start_date"`
+	EndDate     string      `json:"end_date"`
+}
+
+/*
+Searches CTFs with optional params:
+
+	name: string
+	description: string
+	start_date: formatted datetime ex: (2025-04-20T09:00:00Z)
+	end_date: formatted datetime ex: (2025-04-20T09:00:00Z)
+*/
+func (h *Handler) SearchCTFs(c echo.Context) error {
+
+	ctx := context.Background()
+	search := new(OuterSearchParams)
+
+	var startTime, endTime time.Time
+	var err error
+
+	if err := c.Bind(search); err != nil {
+		return c.JSON(http.StatusBadRequest, err.Error())
+	}
+	fmt.Println(search)
+
+	// sqlcSearch is a sub struct, doesn't contain the dates
+	sqlcSearch := new(db.SearchCTFsParams)
+	sqlcSearch.Name = search.Name
+	sqlcSearch.Description = search.Description
+	ctfs, err := h.Queries.SearchCTFs(ctx, *sqlcSearch)
+
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, err.Error())
+	}
+
+	var new_ctfs []db.Ctf
+
+	// if a startDate is given, format it into startTime
+	if search.StartDate != "" {
+
+		startTime, err = time.Parse("2006-01-02T15:04:05Z", search.StartDate)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, err.Error())
+		}
+
+	}
+
+	// if an endDate is given, format it into endTime
+	if search.EndDate != "" {
+
+		endTime, err = time.Parse("2006-01-02T15:04:05Z", search.EndDate)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, err.Error())
+		}
+	}
+
+	// loop through each CTF and append the matches that adhere to the start and end dates, if applicable
+	// if no dates are given, it'll append anyways, so new_ctfs is always correct
+	for _, c := range ctfs {
+		if (!startTime.IsZero() && c.StartDate.Before(startTime)) || (!endTime.IsZero() && c.EndDate.After(endTime)) {
+			continue
+		}
+		new_ctfs = append(new_ctfs, c)
+	}
+
+	return c.JSON(http.StatusOK, new_ctfs)
 }

--- a/backend/handler/ctfs.go
+++ b/backend/handler/ctfs.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"time"
 
@@ -165,7 +164,6 @@ func (h *Handler) SearchCTFs(c echo.Context) error {
 	if err := c.Bind(search); err != nil {
 		return c.JSON(http.StatusBadRequest, err.Error())
 	}
-	fmt.Println(search)
 
 	// sqlcSearch is a sub struct, doesn't contain the dates
 	sqlcSearch := new(db.SearchCTFsParams)

--- a/backend/router/router.go
+++ b/backend/router/router.go
@@ -21,7 +21,11 @@ func SetupRouter(handler *handler.Handler) *echo.Echo {
 	// CTF routes
 	{
 		e.GET("/ctfs", handler.GetJoinedCTFs)
+		e.GET("/ctfs/search", handler.SearchCTFs) // can be changed I think
 		e.GET("/ctfs/:phrase", handler.GetCTF)
+
+		// e.GET("/ctfs/global", handler.GetAllCTFs) List all ctfs, might be redundant
+
 		e.POST("/ctfs", handler.CreateCTF)
 		e.DELETE("/ctfs/:phrase", handler.DeleteCTF)
 		e.PUT("/ctfs/:phrase", handler.UpdateCTF)


### PR DESCRIPTION
- Will check for ctfs based on date, name, and description. Returns an array of CTF's. Each field is optional

EX queries:

{
    "name": "Oregon"
} // returns only CTFs that have Oregon in the name

{
    "name": "Oregon",
     "description": "xyz",
     "start_date": "2025-02-21T12:00:00Z"
}// returns only CTFs that have Oregon in the name and a description that contains xyz, that occur after Feb 21st, 2025 at Noon

